### PR TITLE
Feature 20150622 time periods

### DIFF
--- a/events/factories.py
+++ b/events/factories.py
@@ -1,6 +1,7 @@
 import factory
 
 from django.utils import timezone
+from datetime import timedelta
 
 from . import models
 
@@ -13,3 +14,12 @@ class EventFactory(factory.django.DjangoModelFactory):
 
     time = timezone.now()
     user = factory.SubFactory(EmployeeFactory)
+
+
+class PeriodFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = models.Period
+
+    user = factory.SubFactory(EmployeeFactory)
+    start = factory.SubFactory(EventFactory, user=factory.SelfAttribute('..user'), time=(timezone.now()-timedelta(hours=1)))
+    end = factory.SubFactory(EventFactory, user=factory.SelfAttribute('..user'))

--- a/events/factories.py
+++ b/events/factories.py
@@ -15,6 +15,12 @@ class EventFactory(factory.django.DjangoModelFactory):
     time = timezone.now()
     user = factory.SubFactory(EmployeeFactory)
 
+    @classmethod
+    def _create(cls, model_class, *args, **kwargs):
+        obj = model_class(*args, **kwargs)
+        obj.save_without_period_update()
+        return obj
+
 
 class PeriodFactory(factory.django.DjangoModelFactory):
     class Meta:

--- a/events/forms.py
+++ b/events/forms.py
@@ -1,4 +1,4 @@
-from django.forms import ModelForm, SplitDateTimeField, MultiWidget, DateInput, TimeInput
+from django.forms import ModelForm, SplitDateTimeField, BooleanField, MultiWidget, DateInput, TimeInput
 from django.forms.utils import to_current_timezone
 
 from .models import Event
@@ -24,7 +24,8 @@ class UikitSplitDateTimeWidget(MultiWidget):
 
 class EventForm(ModelForm):
     time = SplitDateTimeField(widget=UikitSplitDateTimeWidget)
+    billable = BooleanField(required=False, initial=True)
 
     class Meta:
         model = Event
-        fields = ['time']
+        fields = ['time', 'billable']

--- a/events/forms.py
+++ b/events/forms.py
@@ -24,7 +24,7 @@ class UikitSplitDateTimeWidget(MultiWidget):
 
 class EventForm(ModelForm):
     time = SplitDateTimeField(widget=UikitSplitDateTimeWidget)
-    billable = BooleanField(required=False, initial=True)
+    billable = BooleanField(required=False)
 
     class Meta:
         model = Event

--- a/events/migrations/0003_period.py
+++ b/events/migrations/0003_period.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+from django.conf import settings
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ('events', '0002_event_user'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='Period',
+            fields=[
+                ('id', models.AutoField(auto_created=True, verbose_name='ID', serialize=False, primary_key=True)),
+                ('end', models.ForeignKey(related_name='end', to='events.Event')),
+                ('start', models.ForeignKey(related_name='start', to='events.Event')),
+                ('user', models.ForeignKey(to=settings.AUTH_USER_MODEL)),
+            ],
+        ),
+    ]

--- a/events/migrations/0004_period_completed.py
+++ b/events/migrations/0004_period_completed.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('events', '0003_period'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='period',
+            name='completed',
+            field=models.BooleanField(default=True),
+        ),
+    ]

--- a/events/migrations/0005_auto_20150623_1023.py
+++ b/events/migrations/0005_auto_20150623_1023.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('events', '0004_period_completed'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='period',
+            name='end',
+            field=models.ForeignKey(null=True, related_name='end', to='events.Event'),
+        ),
+        migrations.AlterField(
+            model_name='period',
+            name='start',
+            field=models.ForeignKey(null=True, related_name='start', to='events.Event'),
+        ),
+    ]

--- a/events/migrations/0006_period_billable.py
+++ b/events/migrations/0006_period_billable.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('events', '0005_auto_20150623_1023'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='period',
+            name='billable',
+            field=models.BooleanField(default=True),
+        ),
+    ]

--- a/events/models.py
+++ b/events/models.py
@@ -1,4 +1,5 @@
 from django.db import models
+from django.utils import timezone
 
 from accounts.models import TimeclockUser
 
@@ -9,6 +10,9 @@ class Event(models.Model):
 
     def __str__(self):
         return str(self.time)
+
+    def save_without_period_update(self, *args, **kwargs):
+        super().save(*args, **kwargs)
 
     def save(self, *args, **kwargs):
         super().save(*args, **kwargs)
@@ -40,4 +44,7 @@ class Period(models.Model):
 
     @property
     def duration(self):
-        return (self.end.time - self.start.time)
+        if self.end:
+            return (self.end.time - self.start.time)
+        else:
+            return (timezone.now() - self.start.time)

--- a/events/models.py
+++ b/events/models.py
@@ -1,4 +1,5 @@
 from django.db import models
+from django.core.exceptions import ValidationError
 
 from accounts.models import TimeclockUser
 
@@ -6,3 +7,28 @@ from accounts.models import TimeclockUser
 class Event(models.Model):
     time = models.DateTimeField()
     user = models.ForeignKey(TimeclockUser)
+
+    def __str__(self):
+        return str(self.time)
+
+    def save(self, *args, **kwargs):
+        last_event = Event.objects.filter(user=self.user).last()
+        super().save(*args, **kwargs)
+        if last_event and not last_event.start.count() and not last_event.end.count():
+            Period(user=self.user, start=last_event, end=self).save()
+
+
+class Period(models.Model):
+    user = models.ForeignKey(TimeclockUser)
+    start = models.ForeignKey(Event, related_name='start')
+    end = models.ForeignKey(Event, related_name='end')
+
+    def save(self, *args, **kwargs):
+        if self.start.user == self.user and self.end.user == self.user:
+            return super().save(*args, **kwargs)
+        else:
+            raise ValidationError('Event user must match period user.')
+
+    @property
+    def duration(self):
+        return (self.end.time - self.start.time)

--- a/events/models.py
+++ b/events/models.py
@@ -15,12 +15,13 @@ class Event(models.Model):
         super().save(*args, **kwargs)
 
     def save(self, *args, **kwargs):
+        billable = kwargs.pop('billable', True)
         super().save(*args, **kwargs)
-        Period.objects.event_occurred(self)
+        Period.objects.event_occurred(self, billable=billable)
 
 
 class PeriodManager(models.Manager):
-    def event_occurred(self, event):
+    def event_occurred(self, event, billable=True):
         """
         Update the user's incomplete period
         """
@@ -31,6 +32,7 @@ class PeriodManager(models.Manager):
         else:
             period.end = event
             period.completed = True
+        period.billable = billable
         period.save()
 
 
@@ -39,6 +41,7 @@ class Period(models.Model):
     start = models.ForeignKey(Event, related_name='start', null=True)
     end = models.ForeignKey(Event, related_name='end', null=True)
     completed = models.BooleanField(default=True)
+    billable = models.BooleanField(default=True)
 
     objects = PeriodManager()
 

--- a/events/templates/base.html
+++ b/events/templates/base.html
@@ -20,10 +20,10 @@
                 <a class="uk-navbar-brand uk-hidden-small" href="layouts_frontpage.html">Timeclock</a>
                 <ul class="uk-navbar-nav uk-hidden-small">
                     <li>
-                        <a href="layouts_frontpage.html">Events</a>
+                        <a href="{% url 'new_event' %}">Events</a>
                     </li>
                     <li>
-                        <a href="layouts_portfolio.html">Reports</a>
+                        <a href="{% url 'periods_index' %}">Periods</a>
                     </li>
                 </ul>
                 <div class="uk-navbar-flip">
@@ -59,10 +59,10 @@
             <div class="uk-offcanvas-bar">
                 <ul class="uk-nav uk-nav-offcanvas">
                     <li>
-                        <a href="layouts_frontpage.html">Events</a>
+                        <a href="{% url 'new_event' %}">Events</a>
                     </li>
                     <li>
-                        <a href="layouts_portfolio.html">Reports</a>
+                        <a href="{% url 'periods_index' %}">Periods</a>
                     </li>
                     {% if user.is_staff %}
                         <li>

--- a/events/templates/events/event_form.html
+++ b/events/templates/events/event_form.html
@@ -4,8 +4,7 @@
     <p>for <strong>{{ user }}</strong></p>
     <form class="uk-form" action="" method="post">
         {% csrf_token %}
-        <label>Time:</label>
-        {{ form.time }}
+        {{ form.as_p }}
         <button type="submit" class="uk-button uk-button-primary uk-button-large">Punch it!</button>
     </form>
 {% endblock content %}

--- a/events/templates/events/period_list.html
+++ b/events/templates/events/period_list.html
@@ -1,0 +1,21 @@
+{% extends "base.html" %}{% load timedelta %}
+{% block content %}
+    <h1>Periods</h1>
+
+    <table class="uk-table">
+        <thead>
+            <th>Start time</th>
+            <th>End time</th>
+            <th>Hours</th>
+        </thead>
+        <tbody>
+            {% for period in period_list %}
+                <tr>
+                    <td>{{ period.start.time|date:"DATETIME_FORMAT" }}</td>
+                    <td>{{ period.end.time|date:"DATETIME_FORMAT" }}</td>
+                    <td>{{ period.duration|in_hours|floatformat:"2" }}</td>
+                </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+{% endblock content %}

--- a/events/templates/events/period_list.html
+++ b/events/templates/events/period_list.html
@@ -7,6 +7,7 @@
             <th>Start time</th>
             <th>End time</th>
             <th>Hours</th>
+            <th>Billable</th>
         </thead>
         <tbody>
             {% for period in period_list %}
@@ -14,6 +15,7 @@
                     <td>{{ period.start.time|date:"DATETIME_FORMAT" }}</td>
                     <td>{{ period.end.time|date:"DATETIME_FORMAT" }}</td>
                     <td>{{ period.duration|in_hours|floatformat:"2" }}</td>
+                    <td>{{ period.billable }}</td>
                 </tr>
             {% endfor %}
         </tbody>

--- a/events/templatetags/timedelta.py
+++ b/events/templatetags/timedelta.py
@@ -1,0 +1,12 @@
+from django import template
+from django.utils.timesince import timesince
+from datetime import timedelta
+
+register = template.Library()
+
+@register.filter
+def in_hours(value, arg=None):
+    if type(value) is not timedelta:
+        return value
+
+    return value.total_seconds() / 60 / 60

--- a/events/tests.py
+++ b/events/tests.py
@@ -1,8 +1,10 @@
 from django.test import TestCase
 from django.utils import timezone
+from django.core.urlresolvers import reverse
+from django.utils import formats
 
-from .factories import EventFactory
-from .models import Event
+from .factories import EventFactory, PeriodFactory
+from .models import Event, Period
 
 from accounts.factories import EmployeeFactory
 
@@ -20,6 +22,21 @@ class EventModelTestCase(TestCase):
         event = EventFactory(user=employee)
 
         self.assertEqual(Event.objects.first().user, employee)
+
+
+class PeriodModelTestCase(TestCase):
+
+    def test_create(self):
+        employee = EmployeeFactory()
+        event1 = EventFactory(user=employee)
+        event2 = EventFactory(user=employee)
+
+        self.assertEqual(Period.objects.count(), 1)
+        period = Period.objects.last()
+        self.assertEqual(period.user, employee)
+        self.assertEqual(period.start, event1)
+        self.assertEqual(period.end, event2)
+
 
 class EventCreateViewTestCase(TestCase):
 
@@ -54,3 +71,20 @@ class EventCreateViewTestCase(TestCase):
         r = self.client.post('/events/new/', {'time_0': '2015-01-01', 'time_1': '01:01:01'})
 
         self.assertEqual(Event.objects.last().user, self.employee)
+
+
+class PeriodListViewTestCase(TestCase):
+
+    def setUp(self):
+        self.employee = EmployeeFactory()
+        self.client.login(username=self.employee.email, password='password')
+
+    def test_get(self):
+        period = PeriodFactory(user=self.employee)
+
+        r = self.client.get(reverse('periods_index'))
+
+        self.assertEqual(r.status_code, 200)
+        formatted_time = formats.date_format(timezone.localtime(period.start.time), "DATETIME_FORMAT")
+        self.assertContains(r, formatted_time)
+        self.assertContains(r, "1.00")

--- a/events/tests.py
+++ b/events/tests.py
@@ -44,6 +44,11 @@ class PeriodModelTestCase(TestCase):
 
         self.assertTrue(Period.objects.last().completed)
 
+    def test_can_be_billable(self):
+        PeriodFactory(billable=True)
+
+        self.assertTrue(Period.objects.last().billable)
+
     def test_event_occurred_start(self):
         employee = EmployeeFactory()
         event = EventFactory(user=employee)
@@ -118,6 +123,11 @@ class EventCreateViewTestCase(TestCase):
         r = self.client.post('/events/new/', {'time_0': '2015-01-01', 'time_1': '01:01:01'})
 
         self.assertEqual(Event.objects.last().user, self.employee)
+
+    def test_post_billable_period(self):
+        r = self.client.post('/events/new/', {'time_0': '2015-01-01', 'time_1': '01:01:01', 'billable': 'False'})
+
+        self.assertEqual(Period.objects.last().billable, False)
 
 
 class PeriodListViewTestCase(TestCase):

--- a/events/tests.py
+++ b/events/tests.py
@@ -37,6 +37,37 @@ class PeriodModelTestCase(TestCase):
         self.assertEqual(period.start, event1)
         self.assertEqual(period.end, event2)
 
+    def test_can_be_completed(self):
+        PeriodFactory(completed=True)
+
+        self.assertTrue(Period.objects.last().completed)
+
+    def test_event_occurred_start(self):
+        employee = EmployeeFactory()
+        event = EventFactory(user=employee)
+        Period.objects.last().delete()
+
+        Period.objects.event_occurred(event)
+
+        period = Period.objects.last()
+
+        self.assertEqual(period.start, event)
+        self.assertEqual(period.end, None)
+
+    def test_event_occurred_end(self):
+        employee = EmployeeFactory()
+        event_start = EventFactory(user=employee)
+        event_end = EventFactory(user=employee)
+        Period.objects.all().delete()
+        PeriodFactory(user=employee, start=event_start, end=None, completed=False)
+
+        Period.objects.event_occurred(event_end)
+
+        period = Period.objects.last()
+
+        self.assertEqual(period.end, event_end)
+        self.assertTrue(period.completed)
+
 
 class EventCreateViewTestCase(TestCase):
 

--- a/events/tests.py
+++ b/events/tests.py
@@ -101,6 +101,19 @@ class EventCreateViewTestCase(TestCase):
 
         self.assertEqual(r.status_code, 200)
 
+    def test_get_sets_billable_to_false(self):
+        event = EventFactory(user=self.employee)
+        period = PeriodFactory(user=self.employee, start=event, completed=False, billable=False)
+
+        r = self.client.get('/events/new/')
+
+        self.assertEqual(r.context['form']['billable'].value(), False)
+
+    def test_get_sets_billable_to_true(self):
+        r = self.client.get('/events/new/')
+
+        self.assertEqual(r.context['form']['billable'].value(), True)
+
     def test_get_sets_default_time(self):
         r = self.client.get('/events/new/')
 

--- a/events/urls.py
+++ b/events/urls.py
@@ -3,5 +3,6 @@ from django.conf.urls import url
 from . import views
 
 urlpatterns = [
-    url(r'^new/$', views.EventCreate.as_view(), name='new_event')
+    url(r'^events/new/$', views.EventCreate.as_view(), name='new_event'),
+    url(r'^periods/$', views.PeriodIndex.as_view(), name='periods_index'),
 ]

--- a/events/views.py
+++ b/events/views.py
@@ -27,9 +27,15 @@ class EventCreate(LoginRequiredMixin, CreateView):
     def get_initial(self):
         """
         Prepopulates date and time with current values for new event creation
+        Prepopulates billable with the incomplete period's setting
         """
         initial = super().get_initial()
 
+        try:
+            billable = Period.objects.get(user=self.request.user, completed=False).billable
+        except Period.DoesNotExist:
+            billable = True
+        initial['billable'] = billable
         initial['time'] = timezone.now().replace(second=0, microsecond=0)
         return initial
 

--- a/events/views.py
+++ b/events/views.py
@@ -1,11 +1,12 @@
 from django.shortcuts import render
 from django.views.generic.edit import CreateView
+from django.views.generic import ListView
 from django.core.urlresolvers import reverse_lazy
 from django.utils import timezone
 from django.http.response import HttpResponseRedirect
 from django.contrib.auth.decorators import login_required
 
-from .models import Event
+from .models import Event, Period
 from .forms import EventForm
 
 from accounts.models import TimeclockUser
@@ -41,3 +42,7 @@ class EventCreate(LoginRequiredMixin, CreateView):
         event.save()
 
         return HttpResponseRedirect(self.success_url)
+
+
+class PeriodIndex(ListView):
+    model = Period

--- a/events/views.py
+++ b/events/views.py
@@ -39,7 +39,7 @@ class EventCreate(LoginRequiredMixin, CreateView):
         """
         event = form.save(commit=False)
         event.user = TimeclockUser.objects.get(email=self.request.user)
-        event.save()
+        event.save(billable=form.cleaned_data['billable'])
 
         return HttpResponseRedirect(self.success_url)
 

--- a/timeclock/urls.py
+++ b/timeclock/urls.py
@@ -17,7 +17,7 @@ from django.conf.urls import include, url
 from django.contrib import admin
 
 urlpatterns = [
+    url(r'^', include('events.urls')),
     url(r'^accounts/', include('accounts.urls')),
-    url(r'^events/', include('events.urls')),
     url(r'^admin/', include(admin.site.urls)),
 ]


### PR DESCRIPTION
## What does this pull request do?

Adds time periods to the app. They are created automatically when events are added to the system. A complete period is displayed with its duration, or if an incomplete period exists it is displayed with the duration up until the current time.
## Sprint.ly Item(s):
#64
## Where should the reviewer start?

events/tests.py
## Definition of Done:
- [X] Code Tested
- [X] Migrations?
